### PR TITLE
Metadata fixes

### DIFF
--- a/lrsctrl/metadata.py
+++ b/lrsctrl/metadata.py
@@ -132,6 +132,8 @@ def get_metadata(f, args):
     end_time_unix, end_time_tai = get_last_event(f, args)
     meta = {}
     path = Path(f)
+    run = get_run(path, args)
+    subrun = get_subrun(path, args)
     cl = Client()
 
     meta['name'] = path.name
@@ -156,8 +158,8 @@ def get_metadata(f, args):
 
         'core.run_type': 'neardet-2x2-lar-light',
 
-        'core.runs': [get_run(path, args)],
-        'core.runs_subruns': [get_subrun(path, args)],
+        'core.runs': [run],
+        'core.runs_subruns': [10000*run + subrun],
 
         'core.first_event_number': start_time_tai, # set wr timestamp as unique event number
         'core.last_event_number': end_time_tai,


### PR DESCRIPTION
Makes the run/subrun numbering consistent with MetaCat's conventions